### PR TITLE
use _pWire instead of Wire.

### DIFF
--- a/DFRobot_ADS1115.cpp
+++ b/DFRobot_ADS1115.cpp
@@ -30,16 +30,15 @@ void DFRobot_ADS1115::setAddr_ADS1115(uint8_t i2cAddress)
  */
 void DFRobot_ADS1115::init()
 {
-  Wire.begin();
+  _pWire->begin();
 }
 
 
 bool DFRobot_ADS1115::checkADS1115()
 {
     uint8_t error;
-    ads_i2cAddress;
-    Wire.beginTransmission(ads_i2cAddress);
-    error = Wire.endTransmission();
+    _pWire->beginTransmission(ads_i2cAddress);
+    error = _pWire.endTransmission();
     if(error == 0){
         return true;
     }else{


### PR DESCRIPTION
The function ::init and ::checkADS1115 used "Wire" instead of  "_pWire". So the library doesnt work when you want to use another I2C port (like Wire1, Wire2, etc)